### PR TITLE
Added the source bundle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,12 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+json-schema-validator-bundle/.classpath
+json-schema-validator-bundle/.project
+json-schema-validator-bundle/.settings/org.eclipse.jdt.core.prefs
+json-schema-validator-bundle/.settings/org.eclipse.m2e.core.prefs
+.settings/org.eclipse.m2e.core.prefs
 /target/
+/.classpath
+/.project

--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,0 +1,1 @@
+/org.eclipse.jdt.core.prefs

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Howto
     * [[3] libphonenumber/issues 205](https://code.google.com/p/libphonenumber/issues/detail?id=205)
 
 
-* build and install json-schema-validator-bundle
+* build and install json-schema-validator-bundle (from the `parent` folder it will also create the source OSGi bundle)
 
 
 usage example:

--- a/parent/.gitignore
+++ b/parent/.gitignore
@@ -1,0 +1,2 @@
+/.settings/
+/.project

--- a/parent/json-schema-validator-source-bundle/.gitignore
+++ b/parent/json-schema-validator-source-bundle/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/.settings/
+/.classpath
+/.project

--- a/parent/json-schema-validator-source-bundle/pom.xml
+++ b/parent/json-schema-validator-source-bundle/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.github.json-schema-validator</groupId>
+    <artifactId>json-schema-validator-bundle-parent</artifactId>
+    <version>2.2.5</version>
+  </parent>
+  <artifactId>json-schema-validator-source-bundle</artifactId>
+  <packaging>bundle</packaging>
+  <name>json-schema-validator :: Source bundle</name>
+  <dependencies>
+  	<dependency>
+  		<groupId>com.github.json-schema-validator</groupId>
+  		<artifactId>${bundle.name}</artifactId>
+  		<version>${bundle.version}</version>
+  		<type>bundle</type>
+    	<!-- Get the source code project -->
+    	<classifier>sources</classifier>
+  	</dependency>
+  </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+                        <Bundle-SymbolicName>${bundle.name}.source</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                        <!-- This defines the bundle we provide the source for -->
+                        <Eclipse-SourceBundle>${bundle.name};version="${bundle.version}";roots:="."</Eclipse-SourceBundle>
+                        <!-- Extract all sources into this bundle -->
+                        <Embed-Dependency>classifier=sources;inline=true</Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <properties>
+    	<bundle.name>json-schema-validator-bundle</bundle.name>
+    	<bundle.version>${project.version}</bundle.version>
+    </properties>
+</project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.github.json-schema-validator</groupId>
+  <artifactId>json-schema-validator-bundle-parent</artifactId>
+  <version>2.2.5</version>
+  <packaging>pom</packaging>
+  <name>json-schema-validator :: parent</name>
+  <modules>
+  	<module>json-schema-validator-source-bundle</module>
+  	<module>..</module>
+  </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,8 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.github.json-schema-validator</groupId>
 	<artifactId>json-schema-validator-bundle</artifactId>
 	<name>json-schema-validator :: Bundle</name>
-	<version>2.2.5</version>
 	<packaging>bundle</packaging>
 
 	<developers>
@@ -259,6 +257,27 @@
 					</instructions>
 				</configuration>
 			</plugin>
+			<!-- Necessary addition to generate the source jar too. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.4</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
+	<parent>
+		<groupId>com.github.json-schema-validator</groupId>
+		<artifactId>json-schema-validator-bundle-parent</artifactId>
+		<version>2.2.5</version>
+		<relativePath>parent</relativePath>
+	</parent>
 </project>


### PR DESCRIPTION
It is a bit weird to have the parent in a subfolder, and also
problematic that for some reason the maven-source-plugin adds the .class
files to the output source jar, but at least the source bundle
generation seems to be working. (Even if the embedded jars do not have
embedded sources. I think the maven-source-plugin is not properly
configured.)
Usage: `mvn install` in the parent folder.
No hard feelings if this is not a good enough option for you, this just
an attempt to fix issue #2.
